### PR TITLE
docs: add Points portal and faucet links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains network configurations for RepublicAI Protocol chains.
 - **gRPC**: grpc.republicai.io:443
 - **EVM JSON-RPC**: https://evm-rpc.republicai.io
 - **Points Portal**: https://points.republicai.io
-- **Testnet Faucet (Points)**: https://points.republicai.io/faucet
+- **Testnet Faucet**: Available via the Points portal (account required)
 
 
 ## Resources


### PR DESCRIPTION
Adds official Points portal and testnet faucet links to help validators and testnet participants onboard more easily.