### PR TITLE
docs: add Community Tools section with republic-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ This repository contains network configurations for RepublicAI Protocol chains.
 - **Testnet Faucet**: Available via the Points portal (account required)
 
 
+## Community Tools
+
+| Tool | Language | Description |
+|------|----------|-------------|
+| [republic-sdk](https://github.com/eren-karakus0/republic-sdk) | TypeScript | SDK for key management, transaction signing, staking, governance & CLI |
+
 ## Resources
 
 - [Website](https://republicai.io) - Official website


### PR DESCRIPTION
## Summary
- Adds a **Community Tools** section to the networks README
- Lists [republic-sdk](https://github.com/eren-karakus0/republic-sdk) as the first community tool

## What is republic-sdk?
A TypeScript SDK for the Republic AI blockchain providing:
- Key management (ethsecp256k1) with encrypted keystore
- Transaction signing (MsgSend, MsgDelegate, MsgVote, etc.)
- Staking & governance queries
- Job submission and monitoring
- Full CLI tool
- 132 tests, CI on Node 18/20

**Install:** `npm install republic-sdk`

## Changes
Only `README.md` — adds a table between Quick Links and Resources sections.